### PR TITLE
add missing permissions for pm update-secret command

### DIFF
--- a/helm-charts/platform-api/templates/platform-api-rbac.yaml
+++ b/helm-charts/platform-api/templates/platform-api-rbac.yaml
@@ -54,6 +54,37 @@ metadata:
     helm.sh/chart: {{ .Release.Name }}
 rules:
 - apiGroups:
+    - icp.ibm.com
+  resources:
+    - passwordrules
+  verbs:
+    - list
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - daemonsets
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - update
+    - patch
+- apiGroups:
+    - ''
+  resources:
+    - namespaces
+  verbs:
+    - get
+- apiGroups:
+    - ''
+  resources:
+    - secrets
+  verbs:
+    - get
+    - update
+- apiGroups:
   - ''
   resources:
   - configmaps


### PR DESCRIPTION
These should be the minimal set of rules for `cloudctl pm update-secret` command to work