### PR TITLE
patch existing platform-api CRs during upgrade

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_platformapi_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_platformapi_cr.yaml
@@ -2,8 +2,6 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: PlatformAPI
 metadata:
   name: platform-api
-  annotations:
-    helm.operator-sdk/upgrade-force: "False"
   labels:
     app.kubernetes.io/instance: platform-api
     app.kubernetes.io/managed-by: platformapis.operator.ibm.com

--- a/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
@@ -306,12 +306,12 @@ spec:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
                 resources:
-                limits:
-                  cpu: "150m"
-                  memory: 256Mi
-                requests:
-                  cpu: "150m"
-                  memory: 256Mi
+                  limits:
+                    cpu: "150m"
+                    memory: 256Mi
+                  requests:
+                    cpu: "150m"
+                    memory: 256Mi
                 command:
                 - sh
                 - -c

--- a/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
@@ -8,9 +8,6 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "PlatformAPI",
           "metadata": {
-            "annotations": {
-              "helm.operator-sdk/upgrade-force": "False"
-            },
             "labels": {
               "app.kubernetes.io/instance": "platform-api",
               "app.kubernetes.io/managed-by": "platformapis.operator.ibm.com",
@@ -316,9 +313,7 @@ spec:
                 - sh
                 - -c
                 - |
-                  kubectl -n ibm-common-services patch platformapis platform-api \
-                    --type json \
-                    -p='[{"op": "replace", "path": "/metadata/annotations/helm.operator-sdk~1upgrade-force", "value": "False"}]'
+                  kubectl annotate platformapis --all helm.operator-sdk/upgrade-force-
               containers:
               - env:
                 - name: WATCH_NAMESPACE

--- a/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
@@ -293,6 +293,32 @@ spec:
                 app.kubernetes.io/name: platformapis.operator.ibm.com
                 name: ibm-platform-api-operator
             spec:
+              initContainers:
+              - name: helm-force-upgrade-false
+                image: quay.io/opencloudio/icp-platform-api@sha256:81e995561b74e8b2a8b54d90514f509dc86491cfbdbe972b93754dafc583de1e
+                imagePullPolicy: Always
+                securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                resources:
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 256Mi
+                command:
+                - sh
+                - -c
+                - |
+                  kubectl -n ibm-common-services patch platformapis platform-api \
+                    --type json \
+                    -p='[{"op": "replace", "path": "/metadata/annotations/helm.operator-sdk~1upgrade-force", "value": "False"}]'
               containers:
               - env:
                 - name: WATCH_NAMESPACE

--- a/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
@@ -295,7 +295,7 @@ spec:
             spec:
               initContainers:
               - name: helm-force-upgrade-false
-                image: quay.io/opencloudio/icp-platform-api@sha256:81e995561b74e8b2a8b54d90514f509dc86491cfbdbe972b93754dafc583de1e
+                image: quay.io/opencloudio/icp-platform-api@sha256:39aef36abb932c1f07423649f13c093063c38aa05d08b2378f986203a3299a58
                 imagePullPolicy: Always
                 securityContext:
                 allowPrivilegeEscalation: false
@@ -334,7 +334,7 @@ spec:
                 - name: OPERAND_AUDIT_SERVICE_IMAGE
                   value: quay.io/opencloudio/icp-audit-service@sha256:24a220374c39652f8b031637d852995bfaec5be2601f9e4c41eb1925531f466d
                 - name: OPERAND_PLATFORM_API_IMAGE
-                  value: quay.io/opencloudio/icp-platform-api@sha256:81e995561b74e8b2a8b54d90514f509dc86491cfbdbe972b93754dafc583de1e
+                  value: quay.io/opencloudio/icp-platform-api@sha256:39aef36abb932c1f07423649f13c093063c38aa05d08b2378f986203a3299a58
                 image: quay.io/opencloudio/ibm-platform-api-operator:latest
                 imagePullPolicy: Always
                 name: ibm-platform-api-operator

--- a/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-platform-api-operator/3.7.0/ibm-platform-api-operator.v3.7.0.clusterserviceversion.yaml
@@ -307,10 +307,10 @@ spec:
                 runAsNonRoot: true
                 resources:
                 limits:
-                  cpu: "1"
-                  memory: 512Mi
+                  cpu: "150m"
+                  memory: 256Mi
                 requests:
-                  cpu: "0.5"
+                  cpu: "150m"
                   memory: 256Mi
                 command:
                 - sh

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: ibm-platform-api-operator
       initContainers:
         - name: helm-force-upgrade-false
-          image: quay.io/opencloudio/icp-platform-api@sha256:81e995561b74e8b2a8b54d90514f509dc86491cfbdbe972b93754dafc583de1e
+          image: quay.io/opencloudio/icp-platform-api@sha256:39aef36abb932c1f07423649f13c093063c38aa05d08b2378f986203a3299a58
           imagePullPolicy: Always
           securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,6 +29,32 @@ spec:
       hostPID: false
       hostIPC: false
       serviceAccountName: ibm-platform-api-operator
+      initContainers:
+        - name: helm-force-upgrade-false
+          image: quay.io/opencloudio/icp-platform-api@sha256:81e995561b74e8b2a8b54d90514f509dc86491cfbdbe972b93754dafc583de1e
+          imagePullPolicy: Always
+          securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: "0.5"
+            memory: 256Mi
+          command:
+          - sh
+          - -c
+          - |
+            kubectl -n ibm-common-services patch platformapis platform-api \
+              --type json \
+              -p='[{"op": "replace", "path": "/metadata/annotations/helm.operator-sdk~1upgrade-force", "value": "False"}]'
       containers:
         - name: ibm-platform-api-operator
           # Replace this with the built image name

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -52,9 +52,7 @@ spec:
           - sh
           - -c
           - |
-            kubectl -n ibm-common-services patch platformapis platform-api \
-              --type json \
-              -p='[{"op": "replace", "path": "/metadata/annotations/helm.operator-sdk~1upgrade-force", "value": "False"}]'
+            kubectl annotate platformapis --all helm.operator-sdk/upgrade-force-
       containers:
         - name: ibm-platform-api-operator
           # Replace this with the built image name

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -43,10 +43,10 @@ spec:
           runAsNonRoot: true
           resources:
           limits:
-            cpu: "1"
-            memory: 512Mi
+            cpu: "150m"
+            memory: 256Mi
           requests:
-            cpu: "0.5"
+            cpu: "150m"
             memory: 256Mi
           command:
           - sh

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -42,12 +42,12 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           resources:
-          limits:
-            cpu: "150m"
-            memory: 256Mi
-          requests:
-            cpu: "150m"
-            memory: 256Mi
+            limits:
+              cpu: "150m"
+              memory: 256Mi
+            requests:
+              cpu: "150m"
+              memory: 256Mi
           command:
           - sh
           - -c


### PR DESCRIPTION
so that the annotation, `helm.operator-sdk/upgrade-force`, is set to `"False"`