### PR TITLE
updated kubeVersion for chart to fix case bundle linting issue;

### DIFF
--- a/helm-charts/platform-api/Chart.yaml
+++ b/helm-charts/platform-api/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - ICP
   - Development
   - Commercial
-kubeVersion: '>=1.11.0-0'
+kubeVersion: '>=1.16.0-0'
 maintainers:
   - email: icpapi@us.ibm.com
     name: IBM Cloud Private


### PR DESCRIPTION
deployment template now contains topologySpreadConstraints, which is
available from k8s version 1.16 onwards