### PR TITLE
updated operator-sdk to v1.7.2 to fix vulnerabilities with base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.3.0
+FROM quay.io/operator-framework/helm-operator:v1.7.2
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator-ppc64le:v1.3.0
+FROM quay.io/operator-framework/helm-operator-ppc64le:v1.7.2
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator-ppc64le:v1.7.2
+FROM quay.io/operator-framework/helm-operator@sha256:23bc7b4cd22a6b0be51e3223df3eb7a07d0abd12ee1318bb8542a8ea375a023a
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator-s390x:v1.3.0
+FROM quay.io/operator-framework/helm-operator-s390x:v1.7.2
 
 ARG VCS_REF
 ARG VCS_URL

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator-s390x:v1.7.2
+FROM quay.io/operator-framework/helm-operator@sha256:8d42cf12f958ad04082354b640ee4d4626c40a5789dda8b614e3df9c42d44421
 
 ARG VCS_REF
 ARG VCS_URL

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,8 @@ domain: ibm.com
 layout: helm.sdk.operatorframework.io/v1
 projectName: ibm-platform-api-operator
 resources:
-- group: operator
+- domain: ibm.com
+  group: operator
   kind: PlatformAPI
   version: v1alpha1
-version: 3-alpha
+version: "3"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,17 +1,21 @@
 FROM scratch
 
+# Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-platform-api-operator-app
 LABEL operators.operatorframework.io.bundle.channels.v1=beta,stable-v1
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.3.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.7.1+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/ibm-platform-api-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-platform-api-operator.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     createdAt: "2020-05-16"
     description: The PlatformAPI operator provides a simple Kubernetes CRD-Based API to manage the lifecycle of PlatformAPI. With this operator, you can simply deploy and upgrade platform-api.
     olm.skipRange: '>=3.5.0 <3.10.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.3.0
+    operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/IBM/ibm-platform-api-operator
     support: IBM

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,12 +1,15 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable-v1
-  operators.operatorframework.io.bundle.channels.v1: beta,stable-v1
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ibm-platform-api-operator-app
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.3.0
+  operators.operatorframework.io.bundle.channels.v1: beta,stable-v1
+  operators.operatorframework.io.bundle.channel.default.v1: stable-v1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.7.1+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
-  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
updated PROJECT configuration file since `3-alpha` is not valid anymore https://github.com/operator-framework/operator-sdk/releases/tag/v1.5.0