### PR TITLE
removed certificate secret defintion from helm chart because

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@ approvers:
 - bitscuit
 - horis233
 - Daniel-Fan
+- ZhuoxiLi
 reviewers:
 - bitscuit
 - horis233
 - Daniel-Fan
+- ZhuoxiLi

--- a/helm-charts/platform-api/templates/platform-api-cert.yaml
+++ b/helm-charts/platform-api/templates/platform-api-cert.yaml
@@ -23,20 +23,3 @@ spec:
   organization:
   - IBM
   secretName: "{{ .Values.platformApi.config.clusterCASecret }}"
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ .Values.platformApi.config.clusterCASecret }}"
-  annotations:
-    helm.sh/resource-policy: "delete"
-  labels:
-    app: "platform-api"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    app.kubernetes.io/name: "platform-api"
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
cert-manager could not update the secret due to error "secrets
\"platform-api-secret\" is forbidden: cannot set blockOwnerDeletion if
an ownerReference refers to a resource you can't set finalizers on: ,
\u003cnil\u003e" "key"="ibm-common-services/platform-api-ca-cert"