### PR TITLE
add pre upgrade hook

### DIFF
--- a/bundle/manifests/ibm-platform-api-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-platform-api-operator.clusterserviceversion.yaml
@@ -270,6 +270,8 @@ spec:
                         value: quay.io/opencloudio/audit-syslog-service:1.0.7
                       - name: ICP_PLATFORM_API_IMAGE
                         value: quay.io/opencloudio/icp-platform-api:3.8.0
+                      - name: KUBECTL_IMAGE
+                        value: quay.io/opencloudio/kubectl:v1.15.9.7
                     image: quay.io/opencloudio/ibm-platform-api-operator:latest
                     imagePullPolicy: Always
                     name: ibm-platform-api-operator
@@ -503,6 +505,18 @@ spec:
               verbs:
                 - create
                 - patch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: ibm-platform-api-operator
     strategy: deployment
   installModes:

--- a/config/development/manager_patch.yaml
+++ b/config/development/manager_patch.yaml
@@ -11,5 +11,7 @@ spec:
           value: "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/audit-syslog-service:1.0.7"
         - name: ICP_PLATFORM_API_IMAGE
           value: "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/icp-platform-api:3.8.0"
+        - name: KUBECTL_IMAGE
+          value: "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/kubectl:v1.15.9.7"
         name: ibm-platform-api-operator
         image: "hyc-cloud-private-scratch-docker-local.artifactory.swg-devops.com/ibmcom/ibm-platform-api-operator-amd64:dev"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,8 @@ spec:
           value: "quay.io/opencloudio/audit-syslog-service:1.0.7"
         - name: ICP_PLATFORM_API_IMAGE
           value: "quay.io/opencloudio/icp-platform-api:3.8.0"
+        - name: KUBECTL_IMAGE
+          value: quay.io/opencloudio/kubectl:v1.15.9.7
         image: "quay.io/opencloudio/ibm-platform-api-operator:latest"
         imagePullPolicy: Always
         name: ibm-platform-api-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -120,7 +120,18 @@ rules:
   - patch
   - update
   - watch
-
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ##
 ## Base operator rules
 ##

--- a/helm-charts/platform-api/templates/pre-upgrade-job.yaml
+++ b/helm-charts/platform-api/templates/pre-upgrade-job.yaml
@@ -1,0 +1,100 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: {{ .Values.platformApi.name }}-upgrade-job
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name:  {{ .Values.platformApi.name }}-upgrade-job
+    helm.sh/chart: {{ .Release.Name }}
+  name: {{ .Values.platformApi.name }}-upgrade-job
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.platformApi.name }}-upgrade-job
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        heritage: {{ .Release.Service }}
+        k8s-app: {{ .Values.platformApi.name }}-upgrade-job
+        component: {{ .Values.platformApi.name }}-upgrade-job
+        release: {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name:  {{ .Values.platformApi.name }}-upgrade-job
+        helm.sh/chart: {{ .Release.Name }}
+      annotations:
+        productName: IBM Cloud Platform Common Services
+        productID: "068a62892a1e4db39641342e592daa25"
+        productMetric: FREE
+        clusterhealth.ibm.com/dependencies: "auth-idp, auth-pap, auth-pdp, cert-manager, icp-management-ingress"
+    spec:
+      serviceAccount: ibm-platform-api-operand
+      serviceAccountName: ibm-platform-api-operand
+      hostPID: false
+      hostIPC: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ .Values.platformApi.name }}-upgrade-job
+              topologyKey: "kubernetes.io/hostname"
+            weight: 100
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            key: app
+            values: {{ .Values.platformApi.name }}-upgrade-job
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/region
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            key: app
+            values: {{ .Values.platformApi.name }}-upgrade-job
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: remove-token-secrets
+        image: {{ .Values.kubectl.image.repository }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+        - bash
+        - /opt/platform-api/bin/clean-up.sh
+        volumeMounts:
+        - name: script
+          mountPath: /opt/platform-api/bin/
+      volumes:
+      - name: script
+        configMap:
+          name: platform-api-pre-upgrade-script
+      restartPolicy: OnFailure

--- a/helm-charts/platform-api/templates/pre-upgrade-script-configmap.yaml
+++ b/helm-charts/platform-api/templates/pre-upgrade-script-configmap.yaml
@@ -31,7 +31,6 @@ data:
 
     kubectl get secrets -n ${NAMESPACE} | grep ibm-platform-api-operand-token | grep -v "${SECRET_NAME}" | cut -d ' ' -f1 | while read secret ; do
         kubectl delete secret $secret -n ${NAMESPACE}
-        sleep 1
     done
 
     if [ $? -ne 0 ]; then

--- a/helm-charts/platform-api/templates/pre-upgrade-script-configmap.yaml
+++ b/helm-charts/platform-api/templates/pre-upgrade-script-configmap.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: platform-api-pre-upgrade-script
+  labels:
+    app: {{ .Values.platformApi.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    k8s-app: {{ .Values.platformApi.name }}
+    component: {{ .Values.platformApi.name }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name:  {{ .Values.platformApi.name }}
+    helm.sh/chart: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+data:
+  clean-up.sh: |
+    #/bin/bash
+
+    echo "Get secrets from platform-api service account..."
+    SECRET_NAME=`kubectl get sa ibm-platform-api-operand -n ${NAMESPACE} -o yaml | grep "\- name: ibm-platform-api-operand-token" | awk '{print $3}'`
+    
+    if [ $? -ne 0 ]; then
+        echo "Failed to get secret ibm-platform-api-operand-token."
+        exit 1
+    fi
+
+    kubectl get secrets -n ${NAMESPACE} | grep ibm-platform-api-operand-token | grep -v "${SECRET_NAME}" | cut -d ' ' -f1 | while read secret ; do
+        kubectl delete secret $secret -n ${NAMESPACE}
+        sleep 1
+    done
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to get secret ibm-platform-api-operand-token."
+        exit 1
+    fi
+
+    echo "Finish secret clean up."

--- a/helm-charts/platform-api/values.yaml
+++ b/helm-charts/platform-api/values.yaml
@@ -53,3 +53,7 @@ platformApi:
 replicaCount: 1
 # replicas: 1
 runAsUser: 65534
+
+kubectl:
+  image:
+    repository: quay.io/opencloudio/kubectl:v1.15.9.7

--- a/watches.yaml
+++ b/watches.yaml
@@ -6,4 +6,5 @@
   overrideValues:
     auditService.image.repository: ${AUDIT_SYSLOG_SERVICE_IMAGE}
     platformApi.image.repository: ${ICP_PLATFORM_API_IMAGE}
+    kubectl.image.repository: ${KUBECTL_IMAGE}
 # +kubebuilder:scaffold:watch


### PR DESCRIPTION
In order to remove the redundant service account secrets involved by helm operator base image defect, we add a pre-upgrade hook in the operator to clean up the service account secrets we don't use. 