### PR TITLE
update liveness and readiness probes to use https instead of http

### DIFF
--- a/helm-charts/platform-api/templates/platform-api-deployment.yaml
+++ b/helm-charts/platform-api/templates/platform-api-deployment.yaml
@@ -172,7 +172,7 @@ spec:
         readinessProbe:
           httpGet:
             path: "/v1/config"
-            scheme: HTTP
+            scheme: HTTPS
             port: 6969
           failureThreshold: 10
           initialDelaySeconds: 5
@@ -181,7 +181,7 @@ spec:
         livenessProbe:
           httpGet:
             path: "/v1/config"
-            scheme: HTTP
+            scheme: HTTPS
             port: 6969
           failureThreshold: 10
           initialDelaySeconds: 15


### PR DESCRIPTION
Signed-off-by: Ben Luzarraga <luzarragaben@ibm.com>