### PR TITLE
Revert "update readiness and liveness probes to use https"

### DIFF
--- a/helm-charts/platform-api/templates/platform-api-deployment.yaml
+++ b/helm-charts/platform-api/templates/platform-api-deployment.yaml
@@ -172,7 +172,7 @@ spec:
         readinessProbe:
           httpGet:
             path: "/v1/config"
-            scheme: HTTPS
+            scheme: HTTP
             port: 6969
           failureThreshold: 10
           initialDelaySeconds: 5
@@ -181,7 +181,7 @@ spec:
         livenessProbe:
           httpGet:
             path: "/v1/config"
-            scheme: HTTPS
+            scheme: HTTP
             port: 6969
           failureThreshold: 10
           initialDelaySeconds: 15


### PR DESCRIPTION
Reverts IBM/ibm-platform-api-operator#222

Operand changes were reverted so this needs to be as well. Once operand changes are verified, I will redo these changes.